### PR TITLE
fix(deps): update intl to ^0.19.0 to resolve Flutter 3.24.0 SDK conflict

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   fl_chart: ^0.66.0
   
   # Utils
-  intl: ^0.18.1
+  intl: ^0.19.0
   logger: ^2.0.2
   freezed_annotation: ^2.4.1
   json_annotation: ^4.8.1


### PR DESCRIPTION
## Summary

Fixes the dependency version conflict between the `intl` package and Flutter 3.24.0 SDK that's causing GitHub Actions CI to fail.

## Problem

GitHub Actions workflow was failing during `flutter pub get` with the following error:
```
Because every version of flutter_localizations from sdk depends on intl 0.19.0 
and foodbegood depends on intl ^0.18.1, flutter_localizations from sdk is forbidden.
```

Flutter 3.24.0 (specified in the CI workflow) pins `intl` to version 0.19.0 through its `flutter_localizations` package, but `pubspec.yaml` was requesting `intl: ^0.18.1`.

## Changes

- **pubspec.yaml**: Update `intl` from `^0.18.1` to `^0.19.0`

## Testing

- [x] Version constraint now compatible with Flutter 3.24.0 SDK
- [x] GitHub Actions should now pass the `flutter pub get` step

## Related Issues

Fixes CI build failures caused by dependency version conflicts.

## Checklist

- [x] Identified root cause of CI failure
- [x] Updated dependency version
- [x] Committed with conventional commit format
- [x] Pushed to feature branch